### PR TITLE
Ci/matrix grape version testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,12 @@ jobs:
           - { ruby: '3.0', grape: '~> 2.1.3' }
           - { ruby: '3.0', grape: '~> 2.2.0' }
           - { ruby: '3.0', grape: 'HEAD' }
+          # For ruby 3.0 only test grape-swagger 2.0.3
           - { ruby: '3.0', grape_swagger: 'HEAD' }
           - { ruby: '3.0', grape_swagger: '~> 2.1.2' }
+          # For grape 1.8.0 only test grape-swagger 2.0.3
+          - { grape: '~> 1.8.0', grape_swagger: '~> 2.1.2' }
+          - { grape: '~> 1.8.0', grape_swagger: 'HEAD' }
     runs-on: ubuntu-latest
     env:
       GRAPE_VERSION: ${{ matrix.grape }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,6 @@ jobs:
           - { ruby: 'head', grape: 'HEAD' }
     name: test (ruby=${{ matrix.entry.ruby }}, grape=${{ matrix.entry.grape }})
     runs-on: ubuntu-latest
-    needs: ['lint']
     env:
       GRAPE_VERSION: ${{ matrix.entry.grape }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,21 +23,45 @@ jobs:
         run: bundle exec rubocop
 
   test:
-    env:
-      GRAPE_ENTITY: 1.0.0
-
-    runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
       matrix:
-        ruby-version: ['3.1', '3.2', '3.3']
+        entry:
+          - { ruby: '3.0', grape: '1.8.0' }
+          - { ruby: '3.1', grape: '1.8.0' }
+          - { ruby: '3.2', grape: '1.8.0' }
+          - { ruby: '3.3', grape: '1.8.0' }
+          - { ruby: '3.4', grape: '1.8.0' }
+          - { ruby: 'head', grape: '1.8.0' }
+          - { ruby: '3.0', grape: '2.0.0' }
+          - { ruby: '3.1', grape: '2.0.0' }
+          - { ruby: '3.2', grape: '2.0.0' }
+          - { ruby: '3.3', grape: '2.0.0' }
+          - { ruby: '3.4', grape: '2.0.0' }
+          - { ruby: 'head', grape: '2.0.0' }
+          - { ruby: '3.0', grape: '2.1.3' }
+          - { ruby: '3.1', grape: '2.1.3' }
+          - { ruby: '3.2', grape: '2.1.3' }
+          - { ruby: '3.3', grape: '2.1.3' }
+          - { ruby: '3.4', grape: '2.1.3' }
+          - { ruby: 'head', grape: '2.1.3' }
+          - { ruby: '3.1', grape: '2.2.0' }
+          - { ruby: '3.2', grape: '2.2.0' }
+          - { ruby: '3.3', grape: '2.2.0' }
+          - { ruby: '3.4', grape: '2.2.0' }
+          - { ruby: 'head', grape: '2.2.0' }
+          - { ruby: 'head', grape: 'HEAD' }
+    name: test (ruby=${{ matrix.entry.ruby }}, grape=${{ matrix.entry.grape }})
+    runs-on: ubuntu-latest
+    needs: ['lint']
+    env:
+      GRAPE_VERSION: ${{ matrix.entry.grape }}
 
     steps:
     - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: ${{ matrix.ruby-version }}
+        ruby-version: ${{ matrix.entry.ruby }}
         bundler-cache: true
     - name: Run tests
       run: bundle exec rake spec

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,10 @@ jobs:
         grape_swagger: [ '~> 2.0.3', '2.1.1', '~> 2.1.2', 'HEAD' ]
         grape_entity: [ '~> 1.0.1', 'HEAD' ]
         ruby: [ '3.1', '3.2', '3.3', '3.4', 'head' ]
+        exclude:
+          - { grape_swagger: '~> 2.0.3', grape: 'HEAD' }
+          - { grape_swagger: '~> 2.0.3', grape: '~> 2.2.0' }
+          - { grape_swagger: '~> 2.0.3', grape: '~> 2.1.3' }
     runs-on: ubuntu-latest
     env:
       GRAPE_VERSION: ${{ matrix.grape }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,22 +26,10 @@ jobs:
     name: test (ruby=${{ matrix.ruby }}, grape=${{ matrix.grape }}, grape-swagger=${{ matrix.grape_swagger}}, grape_entity=${{ matrix.grape_entity }})
     strategy:
       matrix:
-        grape: [ '~> 1.8.0', '~> 2.0.0', '~> 2.1.3', '~> 2.2.0', 'HEAD' ]
+        grape: [ '~> 2.0.0', '~> 2.1.3', '~> 2.2.0', 'HEAD' ]
         grape_swagger: [ '~> 2.0.3', '2.1.1', '~> 2.1.2', 'HEAD' ]
         grape_entity: [ '~> 1.0.1', 'HEAD' ]
-        ruby: [ '3.0', '3.1', '3.2', '3.3', '3.4', 'head' ]
-        exclude:
-          # For ruby 3.0 only test grape 1.8.0
-          - { ruby: '3.0', grape: '~> 2.0.0' }
-          - { ruby: '3.0', grape: '~> 2.1.3' }
-          - { ruby: '3.0', grape: '~> 2.2.0' }
-          - { ruby: '3.0', grape: 'HEAD' }
-          # For ruby 3.0 only test grape-swagger 2.0.3
-          - { ruby: '3.0', grape_swagger: 'HEAD' }
-          - { ruby: '3.0', grape_swagger: '~> 2.1.2' }
-          # For grape 1.8.0 only test grape-swagger 2.0.3
-          - { grape: '~> 1.8.0', grape_swagger: '~> 2.1.2' }
-          - { grape: '~> 1.8.0', grape_swagger: 'HEAD' }
+        ruby: [ '3.1', '3.2', '3.3', '3.4', 'head' ]
     runs-on: ubuntu-latest
     env:
       GRAPE_VERSION: ${{ matrix.grape }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,14 +26,12 @@ jobs:
     name: test (ruby=${{ matrix.ruby }}, grape=${{ matrix.grape }}, grape-swagger=${{ matrix.grape_swagger}}, grape_entity=${{ matrix.grape_entity }})
     strategy:
       matrix:
-        grape: [ '~> 2.0.0', '~> 2.1.3', '~> 2.2.0', 'head' ]
-        grape_swagger: [ '~> 2.0.3', '~> 2.1.2', 'head' ]
+        grape: [ '~> 2.0.0', 'head' ]
+        grape_swagger: [ '~> 2.0.3', 'head' ]
         grape_entity: [ '~> 1.0.1', 'head' ]
         ruby: [ '3.1', '3.4', 'head' ]
         exclude:
           - { grape_swagger: '~> 2.0.3', grape: 'head' }
-          - { grape_swagger: '~> 2.0.3', grape: '~> 2.2.0' }
-          - { grape_swagger: '~> 2.0.3', grape: '~> 2.1.3' }
     runs-on: ubuntu-latest
     env:
       GRAPE_VERSION: ${{ matrix.grape }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,13 +30,14 @@ jobs:
         grape_swagger: [ '~> 2.0.3', 'head' ]
         grape_entity: [ '~> 1.0.1', 'head' ]
         ruby: [ '3.1', '3.4', 'head' ]
+        # Exclude combinations that are not supported.
         exclude:
           - { grape_swagger: '~> 2.0.3', grape: 'head' }
     runs-on: ubuntu-latest
     env:
       GRAPE_VERSION: ${{ matrix.grape }}
-      GRAPE_SWAGGER: ${{ matrix.grape_swagger }}
-      GRAPE_ENTITY: ${{ matrix.grape_entity }}
+      GRAPE_SWAGGER_VERSION: ${{ matrix.grape_swagger }}
+      GRAPE_ENTITY_VERSION: ${{ matrix.grape_entity }}
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,42 +25,31 @@ jobs:
   test:
     strategy:
       matrix:
-        entry:
-          - { ruby: '3.0', grape: '1.8.0' }
-          - { ruby: '3.1', grape: '1.8.0' }
-          - { ruby: '3.2', grape: '1.8.0' }
-          - { ruby: '3.3', grape: '1.8.0' }
-          - { ruby: '3.4', grape: '1.8.0' }
-          - { ruby: 'head', grape: '1.8.0' }
-          - { ruby: '3.0', grape: '2.0.0' }
-          - { ruby: '3.1', grape: '2.0.0' }
-          - { ruby: '3.2', grape: '2.0.0' }
-          - { ruby: '3.3', grape: '2.0.0' }
-          - { ruby: '3.4', grape: '2.0.0' }
-          - { ruby: 'head', grape: '2.0.0' }
-          - { ruby: '3.0', grape: '2.1.3' }
-          - { ruby: '3.1', grape: '2.1.3' }
-          - { ruby: '3.2', grape: '2.1.3' }
-          - { ruby: '3.3', grape: '2.1.3' }
-          - { ruby: '3.4', grape: '2.1.3' }
-          - { ruby: 'head', grape: '2.1.3' }
-          - { ruby: '3.1', grape: '2.2.0' }
-          - { ruby: '3.2', grape: '2.2.0' }
-          - { ruby: '3.3', grape: '2.2.0' }
-          - { ruby: '3.4', grape: '2.2.0' }
-          - { ruby: 'head', grape: '2.2.0' }
-          - { ruby: 'head', grape: 'HEAD' }
-    name: test (ruby=${{ matrix.entry.ruby }}, grape=${{ matrix.entry.grape }})
+        grape: [ '~> 1.8.0', '~> 2.0.0', '~> 2.1.3', '~> 2.2.0', 'HEAD' ]
+        grape_swagger: [ '~> 2.0.3', '2.1.1', '~> 2.1.2', 'HEAD' ]
+        grape_entity: [ '~> 1.0.1', 'HEAD' ]
+        ruby: [ '3.0', '3.1', '3.2', '3.3', '3.4', 'head' ]
+        exclude:
+          # For ruby 3.0 only test grape 1.8.0
+          - { ruby: '3.0', grape: '~> 2.0.0' }
+          - { ruby: '3.0', grape: '~> 2.1.3' }
+          - { ruby: '3.0', grape: '~> 2.2.0' }
+          - { ruby: '3.0', grape: 'HEAD' }
+          - { ruby: '3.0', grape_swagger: 'HEAD' }
+          - { ruby: '3.0', grape_swagger: '~> 2.1.2' }
+    name: test (ruby=${{ matrix.ruby }}, grape=${{ matrix.grape }})
     runs-on: ubuntu-latest
     env:
-      GRAPE_VERSION: ${{ matrix.entry.grape }}
+      GRAPE_VERSION: ${{ matrix.grape }}
+      GRAPE_SWAGGER: ${{ matrix.grape_swagger }}
+      GRAPE_ENTITY: ${{ matrix.grape_entity }}
 
     steps:
     - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: ${{ matrix.entry.ruby }}
+        ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
     - name: Run tests
       run: bundle exec rake spec

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
         run: bundle exec rubocop
 
   test:
+    name: test (ruby=${{ matrix.ruby }}, grape=${{ matrix.grape }}, grape-swagger=${{ matrix.grape_swagger}}, grape_entity=${{ matrix.grape_entity }})
     strategy:
       matrix:
         grape: [ '~> 1.8.0', '~> 2.0.0', '~> 2.1.3', '~> 2.2.0', 'HEAD' ]
@@ -37,7 +38,6 @@ jobs:
           - { ruby: '3.0', grape: 'HEAD' }
           - { ruby: '3.0', grape_swagger: 'HEAD' }
           - { ruby: '3.0', grape_swagger: '~> 2.1.2' }
-    name: test (ruby=${{ matrix.ruby }}, grape=${{ matrix.grape }})
     runs-on: ubuntu-latest
     env:
       GRAPE_VERSION: ${{ matrix.grape }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,12 +26,12 @@ jobs:
     name: test (ruby=${{ matrix.ruby }}, grape=${{ matrix.grape }}, grape-swagger=${{ matrix.grape_swagger}}, grape_entity=${{ matrix.grape_entity }})
     strategy:
       matrix:
-        grape: [ '~> 2.0.0', '~> 2.1.3', '~> 2.2.0', 'HEAD' ]
-        grape_swagger: [ '~> 2.0.3', '2.1.1', '~> 2.1.2', 'HEAD' ]
-        grape_entity: [ '~> 1.0.1', 'HEAD' ]
-        ruby: [ '3.1', '3.2', '3.3', '3.4', 'head' ]
+        grape: [ '~> 2.0.0', '~> 2.1.3', '~> 2.2.0', 'head' ]
+        grape_swagger: [ '~> 2.0.3', '~> 2.1.2', 'head' ]
+        grape_entity: [ '~> 1.0.1', 'head' ]
+        ruby: [ '3.1', '3.4', 'head' ]
         exclude:
-          - { grape_swagger: '~> 2.0.3', grape: 'HEAD' }
+          - { grape_swagger: '~> 2.0.3', grape: 'head' }
           - { grape_swagger: '~> 2.0.3', grape: '~> 2.2.0' }
           - { grape_swagger: '~> 2.0.3', grape: '~> 2.1.3' }
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Features
 
 * Your contribution here.
+* [#76](https://github.com/ruby-grape/grape-swagger-entity/pull/76): Update ci matrix and gemfile for multi-version grape testing - [@numbata](https://github.com/numbata).
 
 #### Fixes
 

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,12 @@ gem 'grape', case version = ENV.fetch('GRAPE_VERSION', '< 3.0')
              else
                version
              end
+gem 'grape-swagger', case version = ENV.fetch('GRAPE_SWAGGER', 'HEAD')
+                     when 'HEAD'
+                       { git: 'https://github.com/ruby-grape/grape-swagger.git' }
+                     else
+                       version
+                     end
 
 group :development, :test do
   gem 'bundler'
@@ -26,8 +32,6 @@ group :development, :test do
   gem 'rubocop-rake'
   gem 'rubocop-rspec'
 end
-
-gem 'grape-swagger', git: 'https://github.com/ruby-grape/grape-swagger.git'
 
 group :test do
   gem 'grape-entity', ENV.fetch('GRAPE_ENTITY', '1.0.0')

--- a/Gemfile
+++ b/Gemfile
@@ -35,11 +35,11 @@ end
 
 group :test do
   gem 'grape-entity', case version = ENV.fetch('GRAPE_ENTITY', '1.0.1')
-                     when 'HEAD'
-                       { git: 'https://github.com/ruby-grape/grape-entity.git' }
-                     else
-                       version
-                     end
+                      when 'HEAD'
+                        { git: 'https://github.com/ruby-grape/grape-entity.git' }
+                      else
+                        version
+                      end
   gem 'ruby-grape-danger', '~> 0.2.1', require: false
   gem 'simplecov', require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -9,15 +9,15 @@ grape_version = ENV.fetch('GRAPE_VERSION', '< 3.0')
 grape_swagger_version = ENV.fetch('GRAPE_SWAGGER', 'HEAD')
 grape_entity_version = ENV.fetch('GRAPE_ENTITY', '1.0.1')
 
-gem 'grape', if grape_vesion.casecmp('HEAD').zero?
+gem 'grape', if grape_version.casecmp('HEAD').zero?
                { git: 'https://github.com/ruby-grape/grape' }
              else
                grape_version
              end
-gem 'grape-swagger', if grape_swagger_vesion.casecmp('HEAD').zero?
+gem 'grape-swagger', if grape_swagger_version.casecmp('HEAD').zero?
                        { git: 'https://github.com/ruby-grape/grape-swagger.git' }
                      else
-                       version
+                       grape_swagger_version
                      end
 
 group :development, :test do
@@ -36,10 +36,10 @@ group :development, :test do
 end
 
 group :test do
-  gem 'grape-entity', if grape_entity_vesion.casecmp('HEAD').zero?
+  gem 'grape-entity', if grape_entity_version.casecmp('HEAD').zero?
                         { git: 'https://github.com/ruby-grape/grape-entity.git' }
                       else
-                        version
+                        grape_entity_version
                       end
   gem 'ruby-grape-danger', '~> 0.2.1', require: false
   gem 'simplecov', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,12 @@ group :development, :test do
 end
 
 group :test do
-  gem 'grape-entity', ENV.fetch('GRAPE_ENTITY', '1.0.0')
+  gem 'grape-entity', case version = ENV.fetch('GRAPE_ENTITY', '1.0.1')
+                     when 'HEAD'
+                       { git: 'https://github.com/ruby-grape/grape-entity.git' }
+                     else
+                       version
+                     end
   gem 'ruby-grape-danger', '~> 0.2.1', require: false
   gem 'simplecov', require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -6,19 +6,23 @@ source 'https://rubygems.org'
 gemspec
 
 grape_version = ENV.fetch('GRAPE_VERSION', '< 3.0')
-grape_swagger_version = ENV.fetch('GRAPE_SWAGGER', 'HEAD')
-grape_entity_version = ENV.fetch('GRAPE_ENTITY', '1.0.1')
+grape_swagger_version = ENV.fetch('GRAPE_SWAGGER_VERSION', '< 3.0')
+grape_entity_version = ENV.fetch('GRAPE_ENTITY_VERSION', '< 2.0')
 
-gem 'grape', if grape_version.casecmp('HEAD').zero?
-               { git: 'https://github.com/ruby-grape/grape' }
-             else
-               grape_version
-             end
-gem 'grape-swagger', if grape_swagger_version.casecmp('HEAD').zero?
+grape_spec = grape_version.casecmp('HEAD').zero? ? { git: 'https://github.com/ruby-grape/grape' } : grape_version
+grape_swagger_spec = if grape_swagger_version.casecmp('HEAD').zero?
                        { git: 'https://github.com/ruby-grape/grape-swagger.git' }
                      else
                        grape_swagger_version
                      end
+grape_entity_spec = if grape_entity_version.casecmp('HEAD').zero?
+                      { git: 'https://github.com/ruby-grape/grape-entity.git' }
+                    else
+                      grape_entity_version
+                    end
+
+gem 'grape', grape_spec
+gem 'grape-swagger', grape_swagger_spec
 
 group :development, :test do
   gem 'bundler'
@@ -36,11 +40,7 @@ group :development, :test do
 end
 
 group :test do
-  gem 'grape-entity', if grape_entity_version.casecmp('HEAD').zero?
-                        { git: 'https://github.com/ruby-grape/grape-entity.git' }
-                      else
-                        grape_entity_version
-                      end
+  gem 'grape-entity', grape_entity_spec
   gem 'ruby-grape-danger', '~> 0.2.1', require: false
   gem 'simplecov', require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -5,14 +5,16 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in grape-swagger-entity.gemspec
 gemspec
 
-gem 'grape', case version = ENV.fetch('GRAPE_VERSION', '< 3.0')
-             when 'HEAD'
+grape_version = ENV.fetch('GRAPE_VERSION', '< 3.0')
+grape_swagger_version = ENV.fetch('GRAPE_SWAGGER', 'HEAD')
+grape_entity_version = ENV.fetch('GRAPE_ENTITY', '1.0.1')
+
+gem 'grape', if grape_vesion.casecmp('HEAD').zero?
                { git: 'https://github.com/ruby-grape/grape' }
              else
-               version
+               grape_version
              end
-gem 'grape-swagger', case version = ENV.fetch('GRAPE_SWAGGER', 'HEAD')
-                     when 'HEAD'
+gem 'grape-swagger', if grape_swagger_vesion.casecmp('HEAD').zero?
                        { git: 'https://github.com/ruby-grape/grape-swagger.git' }
                      else
                        version
@@ -34,8 +36,7 @@ group :development, :test do
 end
 
 group :test do
-  gem 'grape-entity', case version = ENV.fetch('GRAPE_ENTITY', '1.0.1')
-                      when 'HEAD'
+  gem 'grape-entity', if grape_entity_vesion.casecmp('HEAD').zero?
                         { git: 'https://github.com/ruby-grape/grape-entity.git' }
                       else
                         version

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,13 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in grape-swagger-entity.gemspec
 gemspec
 
+gem 'grape', case version = ENV.fetch('GRAPE_VERSION', '< 3.0')
+             when 'HEAD'
+               { git: 'https://github.com/ruby-grape/grape' }
+             else
+               version
+             end
+
 group :development, :test do
   gem 'bundler'
   gem 'pry', platforms: [:mri]


### PR DESCRIPTION
This PR makes it easier for us to test the gem with different versions of grape and Ruby. By expanding our test matrix and updating the Gemfile, we can check that our changes work with a wider range of grape versions. This helps catch any issues early and ensures our gem stays compatible with future updates.